### PR TITLE
Fix Config::get call

### DIFF
--- a/src/migrations/2013_06_20_040924_orchestra_story_make_contents_table.php
+++ b/src/migrations/2013_06_20_040924_orchestra_story_make_contents_table.php
@@ -13,7 +13,7 @@ class OrchestraStoryMakeContentsTable extends Migration {
 	 */
 	public function up()
 	{
-		$format = Config::get('orchestra/story::format', 'markdown');
+		$format = Config::get('orchestra/story::config.default_format', 'markdown');
 
 		Schema::create('story_contents', function ($table) use ($format)
 		{


### PR DESCRIPTION
Config should fail at loading format file and return markdown, but it does not and returns an array.
The call has to be fixed to use the proper key anyway.
